### PR TITLE
fix(nginx): avoid broad match when SUB_NAME is empty

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -8,7 +8,7 @@ http {
     tcp_nodelay on;
     include mime.types;
     default_type text/plain;
-
+    
     server {
         listen ${PORT} ssl;
         server_name ${SERVER_NAME};
@@ -16,14 +16,14 @@ http {
         ssl_certificate /etc/nginx/ssl/fullchain.pem;
         ssl_certificate_key /etc/nginx/ssl/privkey.pem;
 
-        location ~ ^/${URL}/?${SUB_NAME} {
-            rewrite ^/(${URL})/?${SUB_NAME} /$1 break;
+        location ~ ^/${URL}/[^/]+/?${SUB_NAME}$ {
+            rewrite ^/(${URL})/([^/]+)/?${SUB_NAME}$ /$1/$2 break;
             proxy_pass http://app:8000;
             proxy_set_header Host $host;
         }
 
-        location ~ ^/${URL}/[^/]+/?${SUB_NAME} {
-            rewrite ^/(${URL})/([^/]+)/?${SUB_NAME} /$1/$2 break;
+        location ~ ^/${URL}/?${SUB_NAME}$ {
+            rewrite ^/(${URL})/?${SUB_NAME}$ /$1 break;
             proxy_pass http://app:8000;
             proxy_set_header Host $host;
         }


### PR DESCRIPTION
Fix nginx location matching when `SUB_NAME` is empty.

Previously, the generated regexp location could match paths too broadly when
`SUB_NAME` was not set. As a result, requests under `URL` could be intercepted
by the first location block, and the application did not receive the expected
subscription ID/path segment.

This PR separates matching behavior for configured and empty `SUB_NAME` cases
and preserves the captured path parts in rewrite rules.

Fixes #4